### PR TITLE
Update bio and meta to Principal AI Engineer role

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,21 +6,21 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Andrew Hyte | Software Engineer</title>
+    <title>Andrew Hyte | Principal AI Engineer</title>
     <meta
       name="description"
       id="meta-description"
-      content="Andrew Hyte's resume website. Andrew is a Software Engineer with 11 years of professional experience developing web and mobile apps with various flavors of JavaScript and relevant frameworks."
+      content="Andrew Hyte's resume website. Andrew is a Principal AI Engineer building internal AI platforms, agentic coding systems, and modern frontend architectures."
     />
     <meta name="author" content="Andrew Hyte" />
     <meta
       name="keywords"
-      content="Andrew Hyte, Frontend Software Engineer, Full Stack Developer, Web Developer, Mobile Developer, Resume, Job Search, Programmer, Utah, Silicon Slopes, React, Angular, Typescript, JavaScript, Firebase, AWS, Docker, Node.js, mySQL, Lit, Storybook, Vite, Netlify, Figma, React Native, Webpack, Java, Python, Ruby, C#, Postgres, Xamarin, Flutter, Lead Developer, Frontend Engineer, Software Development, Tech Resume"
+      content="Andrew Hyte, Principal AI Engineer, Applied AI, Agentic AI, Claude Code, MCP, Context Engineering, LLM Evaluation, Frontend Software Engineer, Full Stack Developer, Web Developer, Resume, Utah, Silicon Slopes, React, Angular, Typescript, JavaScript, Firebase, AWS, Docker, Node.js, Lit, Storybook, Vite, Netlify, Figma, MicroFrontend, SingleSPA, Software Development, Tech Resume"
     />
-    <meta property="og:title" content="Andrew Hyte - Resume" />
+    <meta property="og:title" content="Andrew Hyte - Principal AI Engineer" />
     <meta
       property="og:description"
-      content="#OpenToWork - Andrew is a Software Engineer with 11 years of professional web development experience."
+      content="Principal AI Engineer building internal AI platforms that let engineering teams ship software faster without sacrificing quality."
     />
     <meta
       property="og:image"
@@ -29,10 +29,10 @@
     <meta property="og:url" content="https://andrew.hyte.us" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Andrew Hyte - Resume" />
+    <meta name="twitter:title" content="Andrew Hyte - Principal AI Engineer" />
     <meta
       name="twitter:description"
-      content="#OpenToWork - Andrew is a Software Engineer with 11 years of professional web development experience."
+      content="Principal AI Engineer building internal AI platforms that let engineering teams ship software faster without sacrificing quality."
     />
     <meta
       name="twitter:image"
@@ -270,25 +270,33 @@
               </div>
               <div class="col-md-8">
                 <p>
-                  Andrew Hyte is a Senior Software Engineer specializing in
-                  modern frontend architectures and applied AI solutions. At
-                  Fishbowl Inventory, he architected and implemented a
-                  production MicroFrontend solution using SingleSPA that unified
-                  multiple products built in different JS technologies,
-                  eliminating legacy dependencies. He won the company-wide
-                  Applied AI Hackathon as team lead, building a conversational
-                  agent with MCP server integration that automated common user
-                  workflows. He also led a 20-member engineering pod as Scrum
-                  Master and championed adoption of cutting-edge AI coding tools
-                  from Codeium Windsurf to Claude Code across the engineering
-                  department.
+                  Andrew Hyte is a Principal AI Engineer at Fishbowl Inventory
+                  building the internal AI platform that lets engineering teams
+                  ship software faster without sacrificing quality. His work
+                  spans three layers of the agentic stack: context engineering
+                  systems that transform stakeholder requirements and
+                  institutional knowledge into structured inputs, agentic
+                  execution environments where Claude Code and MCP-based systems
+                  plan, implement, and iterate against real production
+                  codebases, and LLM evaluation loops that verify agent output
+                  against business intent before human review.
                 </p>
                 <p>
-                  Previously, as Lead Frontend Engineer at ON Platform (GameOn),
-                  he developed a B2B portal for customizing conversational AI
-                  Chatbots and built a no-code Canvas drag-and-drop reply flow
-                  editor. He also optimized CI/CD with Vite, Netlify, and GitHub
-                  Actions.
+                  Promoted from Software Engineering Manager and Senior Software
+                  Engineer, Andrew previously architected Fishbowl's production
+                  MicroFrontend solution with SingleSPA, unifying products built
+                  in React and Angular, and won the company-wide Applied AI
+                  Hackathon as team lead by building a conversational agent with
+                  an MCP server that automated common user workflows in two
+                  days. He led a 20-member pod as Scrum Master and drove
+                  adoption of cutting-edge AI coding tools across engineering.
+                </p>
+                <p>
+                  Before Fishbowl, as Lead Frontend Engineer at ON Platform
+                  (GameOn), he shipped a B2B portal for customizing
+                  conversational AI chatbots and built a no-code Canvas
+                  drag-and-drop reply-flow editor, while optimizing CI/CD with
+                  Vite, Netlify, and GitHub Actions.
                 </p>
                 <p>
                   Earlier roles at Bark Technologies and Router Limits saw him
@@ -532,7 +540,7 @@
           "https://www.linkedin.com/in/andrew-hyte",
           "https://github.com/hytea"
         ],
-        "jobTitle": "Senior Software Engineer",
+        "jobTitle": "Principal AI Engineer",
         "worksFor": {
           "@type": "Organization",
           "name": "Fishbowl Inventory"

--- a/src/main.js
+++ b/src/main.js
@@ -148,7 +148,7 @@ function updateMetaDescription() {
   if (metaDescription) {
     metaDescription.setAttribute(
       'content',
-      `Andrew Hyte's resume website. Andrew is a Lead Frontend Software Engineer with ${yearsOfExperience} years of professional experience developing web and mobile apps with various flavors of JavaScript and relevant frameworks.`
+      `Andrew Hyte's resume website. Andrew is a Principal AI Engineer with ${yearsOfExperience} years of professional experience building internal AI platforms, agentic coding systems, and modern frontend architectures.`
     );
   }
 }


### PR DESCRIPTION
## Summary
- Updates the bio, page title, meta description/keywords, OG/Twitter cards, and `jobTitle` structured data to reflect the Principal AI Engineer role introduced in PR #9 (which only touched `public/config.json`).
- Reframes the bio around the three-layer agentic stack (context engineering, agentic execution, LLM evaluation) consistent with `config.json`'s summary.
- Makes the meta description's years-of-experience programmatic — removes the hardcoded "13 years" so `src/main.js` can populate it from `new Date().getFullYear() - 2013` on load, matching how every other year count on the site works.

## Test plan
- [ ] Confirm hero, bio copy, and page title render correctly at http://localhost:5173/
- [ ] View page source and confirm `<title>` and meta description reflect Principal AI Engineer
- [ ] Confirm years-of-experience in the meta description updates programmatically
- [ ] Spot-check structured data block for `jobTitle: Principal AI Engineer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)