### PR TITLE
Hide sticky side nav below lg breakpoint to fix tablet overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
 
     <div class="container-fluid">
       <div class="row">
-        <aside class="col-lg-2 bg-light pt-4 d-none d-sm-block side-nav-sticky">
+        <aside class="col-lg-2 bg-light pt-4 d-none d-lg-block side-nav-sticky">
           <ul class="nav flex-column side-nav">
             <li class="nav-item">
               <a class="nav-link side-nav-link" href="#bio" data-section="bio">


### PR DESCRIPTION
## Summary
At 576–991px viewports the side nav \`aside\` had \`col-lg-2\` (no allocated grid column below lg) with \`d-sm-block\` (visible). It stacked atop the main content while keeping \`position: sticky; top: 70px\` — bleeding through behind content as the page scrolled.

Switch the visibility breakpoint to \`d-lg-block\` so the side nav only renders when there's a dedicated column for it. The top navbar's collapsed hamburger menu already provides navigation below lg.

## Test plan
- [x] No side nav overlap at 768px; content takes full width
- [x] Side nav still renders correctly at 1200px

🤖 Generated with [Claude Code](https://claude.com/claude-code)