### PR TITLE
[codex] Restore Principal AI Engineer timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,13 +296,14 @@
                   tooling an engineer uses.
                 </p>
                 <p>
-                  Before that move, Andrew built the AI tooling stack inside
-                  Engineering: a Claude Code agentic coding pipeline,
-                  MCP-based context and integration servers, context engineering
-                  systems that turn stakeholder requirements into agent-ready
-                  work, and LLM evaluation loops that verify quality before
-                  human review. Adoption was broad, with productivity gains
-                  visible in GitLab commit activity improving across the team.
+                  Before that move, as Principal AI Engineer, Andrew built AI
+                  coding tools and workflows across Product and Engineering: a
+                  Claude Code agentic coding pipeline, MCP-based context and
+                  integration servers, context engineering systems that turn
+                  stakeholder requirements into agent-ready work, and LLM
+                  evaluation loops that verify quality before human review.
+                  Adoption was broad, with productivity gains visible in GitLab
+                  commit activity improving across the team.
                 </p>
                 <p>
                   That success led to a company-wide mandate: define an AI

--- a/public/config.json
+++ b/public/config.json
@@ -6,7 +6,7 @@
     "website": "Andrew.Hyte.us"
   },
   "outputFileName": "Andrew-Hyte-Resume.pdf",
-  "summary": "AI Architect building company-wide AI platforms that make advanced tooling accessible to technical and non-technical employees. Expertise across <span class=\"feature\">AI platform architecture</span>, <span class=\"feature\">MCP / federated connectors</span>, <span class=\"feature\">agentic workflow design</span>, <span class=\"feature\">context engineering</span>, and <span class=\"feature\">LLM evaluation</span> loops that verify agent output against business intent before human review. Built Fishbowl's engineering AI tooling stack around Claude Code, MCP servers, cloud execution, and structured requirements, driving adoption visible in team-wide GitLab commit activity. Applied AI Hackathon winner with a track record of taking concepts from prototype to production and solving complex architectural challenges, including <span class=\"feature\">MicroFrontend solutions</span> that unify disparate technology stacks.",
+  "summary": "AI Architect building company-wide AI platforms that make advanced tooling accessible to technical and non-technical employees. Expertise across <span class=\"feature\">AI platform architecture</span>, <span class=\"feature\">MCP / federated connectors</span>, <span class=\"feature\">agentic workflow design</span>, <span class=\"feature\">context engineering</span>, and <span class=\"feature\">LLM evaluation</span> loops that verify agent output against business intent before human review. Built Fishbowl's Product and Engineering AI coding stack around Claude Code, MCP servers, cloud execution, and structured requirements, driving adoption visible in team-wide GitLab commit activity. Applied AI Hackathon winner with a track record of taking concepts from prototype to production and solving complex architectural challenges, including <span class=\"feature\">MicroFrontend solutions</span> that unify disparate technology stacks.",
   "experience": [
     {
       "company": "Fishbowl Inventory",
@@ -17,17 +17,27 @@
           "dateRange": "June 2026 - Present (Promoted)",
           "location": "Orem, UT, Remote",
           "responsibilities": [
-            "Moved into the IT department leading a new AI Ops team to extend the engineering AI tooling stack into a company-wide platform for technical and non-technical employees.",
-            "Built the Engineering AI stack: Claude Code agentic coding pipeline, MCP-based context and integration servers, context engineering systems that structure stakeholder requirements into agent-ready work, and LLM evaluation loops for quality verification.",
-            "Drove measured adoption with strong engineering buy-in; productivity gains showed up in GitLab commit activity improving across the board instead of concentrating around a few power users.",
+            "Moved into the IT department leading a new AI Ops team to extend proven AI tooling patterns into a company-wide platform for technical and non-technical employees.",
             "Defined an AI Baseline that gives every employee access to the same caliber of AI tooling an engineer uses, narrowing the internal divide between AI haves and have-nots.",
             "Designed the company AI architecture as Policy, Kernel, Services, Shells, and Apps, with an Equity Lane separating centrally funded AI Baseline access from an opt-in AI Power tier for technical roles.",
             "Shipped the Atlas federated MCP connector framework, connecting upstream vendor MCP servers and re-exposing their tools through one factory call; the first Salesforce connector became a ~1KB declarative definition with an 87% code reduction and 280+ TDD tests."
           ]
         },
         {
+          "title": "Principal AI Engineer",
+          "dateRange": "March 2026 - May 2026 (Promoted)",
+          "location": "Orem, UT, Remote",
+          "responsibilities": [
+            "Built AI coding tools and workflows across the Product and Engineering orgs, turning early experimentation into repeatable operating patterns for real product work.",
+            "Architected the Claude Code agentic coding pipeline, MCP-based context and integration servers, and cloud execution environment where agents plan, implement, test, and iterate against production codebases.",
+            "Designed context engineering systems that gather stakeholder requirements, constraints, and institutional knowledge, then transform them into structured inputs that agentic coding systems can reliably consume.",
+            "Built LLM evaluation and automated review loops that verify agent output against business intent and code quality expectations before work reaches a human reviewer.",
+            "Drove measured adoption with strong buy-in across Product and Engineering; productivity gains showed up in GitLab commit activity improving across the board instead of concentrating around a few power users."
+          ]
+        },
+        {
           "title": "Software Engineering Manager",
-          "dateRange": "December 2025 - April 2026 (Promoted)",
+          "dateRange": "December 2025 - February 2026 (Promoted)",
           "location": "Orem, UT, Remote",
           "responsibilities": [
             "Lead and manage the Fishbowl Inventory cloud application engineering team.",
@@ -40,7 +50,7 @@
         },
         {
           "title": "Senior Software Engineer",
-          "dateRange": "August 2024 - December 2025 (Promoted)",
+          "dateRange": "August 2024 - November 2025 (Promoted)",
           "location": "Orem, UT, Remote",
           "responsibilities": [
             "Architected and implemented MicroFrontend solution using SingleSPA to unify multiple products built in different JS technologies (React, Angular), eliminating dependency on legacy product architecture and enabling independent deployment.",


### PR DESCRIPTION
## Summary

- Add Principal AI Engineer back as its own Fishbowl role from March 2026 through May 2026.
- Rebalance the Fishbowl role dates so the timeline aligns cleanly at month granularity with the June 1 AI Architect promotion.
- Keep AI Architect focused on the company-wide IT / AI Ops charter while Principal AI Engineer covers AI coding tools and workflows across Product and Engineering.

## Validation

- `npm run build`
- Confirmed Fishbowl role order and dates:
  - AI Architect: June 2026 - Present
  - Principal AI Engineer: March 2026 - May 2026
  - Software Engineering Manager: December 2025 - February 2026
  - Senior Software Engineer: August 2024 - November 2025