### PR TITLE
Update principal title to Principal Enterprise AI Architect on resume

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -24,7 +24,7 @@
           ]
         },
         {
-          "title": "Principal AI Engineer",
+          "title": "Principal Enterprise AI Architect",
           "dateRange": "March 2026 - May 2026 (Promoted)",
           "location": "Orem, UT, Remote",
           "responsibilities": [


### PR DESCRIPTION
## Summary
Updates the job title for the principal role from **Principal AI Engineer** to **Principal Enterprise AI Architect** to reflect the official title change.

## Changes
- `public/config.json`: updated the role title in the resume experience data.

## Scope
Per request, the title is only updated on the resume. The bio prose in `index.html` (which references "as Principal AI Engineer") was intentionally left unchanged since the new title is a mouthful and doesn't read as naturally in narrative copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUuHSwcfLdc172KWrcneSf)_